### PR TITLE
fix: heartbeat interval and add onRune hook

### DIFF
--- a/wakatime.lua
+++ b/wakatime.lua
@@ -518,8 +518,14 @@ function onScrollDown(bp)
     return true
 end
 
+function onRune(bp, r)
+    onEvent(bp.buf.AbsPath, false)
+
+    return true
+end
+
 function enoughTimePassed(time)
-    return lastHeartbeat + 120000 < time
+    return lastHeartbeat + 120 < time
 end
 
 function onEvent(file, isWrite)


### PR DESCRIPTION
This fixes two issues in the Micro plugin:

- `enoughTimePassed` compared `os.time()` (seconds) against `120000`, which prevented normal 2-minute heartbeat behavior.
- Added `onRune(bp, r)` so normal typing triggers heartbeats through the existing `onEvent` path.

Result:
- Heartbeats now send roughly every 2 minutes during continuous typing without requiring manual saves.
- This fixes severe undercounting for typing-heavy sessions.

Tested by:
- Running micro -debug
- Typing continuously for 30+ minutes (without saving)
- Confirming `Sending heartbeat` appears about every 2 minutes in log